### PR TITLE
Update version to 2025.4.2 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "splurge-sql-runner"
-version = "2025.4.1"
+version = "2025.4.2"
 description = "A Python utility for executing SQL files against databases with support for multiple statements, comments, and pretty-printed results"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
This pull request updates the package version in the `pyproject.toml` file. The new version is now `2025.4.2`, reflecting a minor release update.